### PR TITLE
Fix manifest load-all chunk selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(NOT CMAKE_C_COMPILER AND NOT CMAKE_CXX_COMPILER)
 endif()
 
 project(zelph VERSION 0.9.6 LANGUAGES C CXX)
-set(ZELPH_VERSION_SUFFIX "-dev")
+set(ZELPH_VERSION_SUFFIX "-dev" CACHE STRING "Version suffix appended to the reported project version")
 
 include(GNUInstallDirs)
 

--- a/src/lib/command_executor.cpp
+++ b/src/lib/command_executor.cpp
@@ -48,6 +48,7 @@ along with zelph. If not, see <https://www.gnu.org/licenses/>.
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <sstream>
 
@@ -416,6 +417,55 @@ private:
             throw std::runtime_error("Command .index-file: Failed to open output file '" + output_filename + "'");
         }
 
+        auto escape_json_string = [](const std::string& value)
+        {
+            std::ostringstream escaped;
+            for (unsigned char ch : value)
+            {
+                switch (ch)
+                {
+                case '\"':
+                    escaped << "\\\"";
+                    break;
+                case '\\':
+                    escaped << "\\\\";
+                    break;
+                case '\b':
+                    escaped << "\\b";
+                    break;
+                case '\f':
+                    escaped << "\\f";
+                    break;
+                case '\n':
+                    escaped << "\\n";
+                    break;
+                case '\r':
+                    escaped << "\\r";
+                    break;
+                case '\t':
+                    escaped << "\\t";
+                    break;
+                default:
+                    if (ch < 0x20)
+                    {
+                        escaped << "\\u"
+                                << std::hex
+                                << std::setw(4)
+                                << std::setfill('0')
+                                << static_cast<int>(ch)
+                                << std::dec
+                                << std::setfill(' ');
+                    }
+                    else
+                    {
+                        escaped << static_cast<char>(ch);
+                    }
+                    break;
+                }
+            }
+            return escaped.str();
+        };
+
         auto write_chunk_array = [&](const char* key, const std::vector<BinChunkRef>& refs)
         {
             out << "  \"" << key << "\": [\n";
@@ -427,11 +477,11 @@ private:
                     << ",\"length\":" << ref.length;
                 if (!ref.which.empty())
                 {
-                    out << ",\"which\":\"" << ref.which << "\"";
+                    out << ",\"which\":\"" << escape_json_string(ref.which) << "\"";
                 }
                 if (!ref.lang.empty())
                 {
-                    out << ",\"lang\":\"" << ref.lang << "\"";
+                    out << ",\"lang\":\"" << escape_json_string(ref.lang) << "\"";
                 }
                 out << "}";
                 if (i + 1 < refs.size())
@@ -444,7 +494,7 @@ private:
         };
 
         out << "{\n";
-        out << "  \"file\":\"" << data.filename << "\",\n";
+        out << "  \"file\":\"" << escape_json_string(data.filename) << "\",\n";
         out << "  \"header\":{\"offset\":0,\"length\":" << data.header_length_bytes << "},\n";
         write_chunk_array("left", data.left_chunks);
         out << ",\n";
@@ -490,11 +540,20 @@ private:
             try
             {
                 size_t   pos   = 0;
-                uint32_t index = static_cast<uint32_t>(std::stoul(token, &pos, 10));
+                if (token[0] == '-')
+                {
+                    throw std::runtime_error("");
+                }
+                uint64_t parsed = std::stoull(token, &pos, 10);
                 if (pos != token.size())
                 {
                     throw std::runtime_error("");
                 }
+                if (parsed > std::numeric_limits<uint32_t>::max())
+                {
+                    throw std::runtime_error("");
+                }
+                uint32_t index = static_cast<uint32_t>(parsed);
                 indices.push_back(index);
             }
             catch (...)
@@ -540,6 +599,10 @@ private:
             try
             {
                 size_t   pos = 0;
+                if (token[0] == '-')
+                {
+                    throw std::runtime_error("");
+                }
                 uint64_t id  = std::stoull(token, &pos, 10);
                 if (pos != token.size())
                 {
@@ -1844,6 +1907,11 @@ private:
             {
                 throw std::runtime_error("Command .load-partial: Unknown selector '" + key + "'");
             }
+        }
+
+        if (use_manifest && source_bin_override.empty() && first_arg.ends_with(".bin"))
+        {
+            source_bin_override = first_arg;
         }
 
         if ((selection.route_nodes_explicit || selection.route_name_explicit) && !use_manifest)

--- a/src/lib/command_executor.hpp
+++ b/src/lib/command_executor.hpp
@@ -64,11 +64,11 @@ namespace zelph::console
          *
          * @param reasoning Pointer to the reasoning network (must remain valid).
          * @param script_engine Pointer to the script engine (must remain valid).
-         * @param data_manager Reference to the shared_ptr holding the data manager (allows replacement).
+         * @param repl_state Shared REPL state used for mode flags and buffers.
          * @param line_processor Callback to process a raw line (used for .import recursion).
          */
         CommandExecutor(zelph::network::Reasoning* reasoning,
-                        zelph::ScriptEngine*       script_engine,
+                        zelph::ScriptEngine*        script_engine,
                         std::shared_ptr<ReplState> repl_state,
                         LineProcessor              line_processor);
 

--- a/src/lib/interactive.cpp
+++ b/src/lib/interactive.cpp
@@ -81,6 +81,15 @@ public:
         auto output = _n->get_output_handler(); // save what's needed
         _n.reset();                             // destroy last
 
+        _repl_state->partial_load_mode         = false;
+        _repl_state->partial_load_source.clear();
+        _repl_state->janet_buffer.clear();
+        _repl_state->zelph_buffer.clear();
+        _repl_state->accumulating_inline_janet = false;
+        _repl_state->accumulating_zelph        = false;
+        _repl_state->script_mode               = ScriptMode::Zelph;
+        _repl_state->reset_requested           = false;
+
         init(output);
         _n->out("Cleared network and re-initialized core nodes.");
     }

--- a/src/lib/network/zelph_impl.hpp
+++ b/src/lib/network/zelph_impl.hpp
@@ -1854,7 +1854,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.left.chunks)
                 {
-                    if (leftSelection.count(ref.chunk_index) != 1) continue;
+                    if (leftSelectionPtr != nullptr && leftSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);
@@ -1923,7 +1923,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.right.chunks)
                 {
-                    if (rightSelection.count(ref.chunk_index) != 1) continue;
+                    if (rightSelectionPtr != nullptr && rightSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);
@@ -2002,7 +2002,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.name_of_node.chunks)
                 {
-                    if (nameOfNodeSelection.count(ref.chunk_index) != 1) continue;
+                    if (nameOfNodeSelectionPtr != nullptr && nameOfNodeSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);
@@ -2077,7 +2077,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.node_of_name.chunks)
                 {
-                    if (nodeOfNameSelection.count(ref.chunk_index) != 1) continue;
+                    if (nodeOfNameSelectionPtr != nullptr && nodeOfNameSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -23,7 +23,7 @@
 
 include(FetchContent)
 
-# doctest v2.4.11 declares cmake_minimum_required(VERSION 3.1),
+# doctest v2.4.12 declares cmake_minimum_required(VERSION 3.1),
 # which newer CMake rejects. Allow it to configure anyway.
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "")
 


### PR DESCRIPTION
This follow-up fixes the manifest-mode load-all path after PR #25.

Problem
- In , when no explicit chunk selectors are provided, the corresponding selection pointer is , but the inner per-chunk loop still checked  and skipped every chunk.
- That meant  could degenerate into loading no payload chunks even though the command/help/docs say omitted selectors should load all.

Fix
- Apply the per-chunk  filter only when the corresponding selection pointer is non-null.
- This change is applied symmetrically for:
  - 
  - 
  - 
  - 

Validation
- Rebasing done onto current .
- Local rebuild passed:
  - [  6%] Built target bz2
[ 26%] Built target kj
[ 33%] Built target kj-async
[ 45%] Built target capnp
[ 47%] Built target kj-test
[ 49%] Built target kj-http
[ 51%] Built target kj-gzip
[ 60%] Built target capnp-rpc
[ 62%] Built target capnpc_capnp
[ 63%] Built target capnpc_cpp
[ 65%] Built target capnp-json
[ 67%] Built target capnp-websocket
[ 76%] Built target capnpc
[ 78%] Built target capnp_tool
[ 99%] Built target zelph_lib
[100%] Built target zelph

This is the issue Stefan flagged in the PR #24 comment thread and again after merging PR #25 into .