### PR TITLE
Fix manifest load-all chunk selection

### DIFF
--- a/src/lib/network/zelph_impl.hpp
+++ b/src/lib/network/zelph_impl.hpp
@@ -1854,7 +1854,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.left.chunks)
                 {
-                    if (leftSelection.count(ref.chunk_index) != 1) continue;
+                    if (leftSelectionPtr != nullptr && leftSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);
@@ -1923,7 +1923,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.right.chunks)
                 {
-                    if (rightSelection.count(ref.chunk_index) != 1) continue;
+                    if (rightSelectionPtr != nullptr && rightSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);
@@ -2002,7 +2002,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.name_of_node.chunks)
                 {
-                    if (nameOfNodeSelection.count(ref.chunk_index) != 1) continue;
+                    if (nameOfNodeSelectionPtr != nullptr && nameOfNodeSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);
@@ -2077,7 +2077,7 @@ namespace zelph::network
             {
                 for (const auto& ref : manifest_description.node_of_name.chunks)
                 {
-                    if (nodeOfNameSelection.count(ref.chunk_index) != 1) continue;
+                    if (nodeOfNameSelectionPtr != nullptr && nodeOfNameSelection.count(ref.chunk_index) != 1) continue;
 
                     const bool     is_sharded_ref   = (manifest_description.is_v2 || manifest_description.is_v3) && !ref.object_path.empty();
                     const uint64_t source_offset    = is_sharded_ref ? 0 : (ref.has_source_offset ? ref.source_offset : 0);


### PR DESCRIPTION
This follow-up fixes the manifest-mode load-all path after PR #25.\n\nProblem\n- When no explicit chunk selectors are provided, the corresponding selection pointer is null, but the inner per-chunk loop still checked the selection set and skipped every chunk.\n- That meant  could load no payload chunks even though omitted selectors are documented to mean load all.\n\nFix\n- Apply the per-chunk selection filter only when the corresponding selection pointer is non-null.\n- The change is applied symmetrically for left, right, nameOfNode, and nodeOfName.\n\nValidation\n- Rebased onto current .\n- Local rebuild passed.\n\nThis is the issue Stefan flagged in the PR #24 thread and again after PR #25.