### PR TITLE
Make HF remote cache revision-aware

### DIFF
--- a/dev_scripts/test_hf_cache_revalidation.sh
+++ b/dev_scripts/test_hf_cache_revalidation.sh
@@ -27,14 +27,14 @@ rm -rf "${CACHE}"
 mkdir -p "${CACHE}"
 
 run_load() {
-    printf '.load-partial %s left=0 right=0 nameOfNode=0 nodeOfName=0\n.quit\n' "${MANIFEST}" \
+    printf '.load-partial %s meta-only\n.quit\n' "${MANIFEST}" \
         | ZELPH_HF_CACHE_DIR="${CACHE}" "${ZELPH}" 2>&1
 }
 
 require_successful_load() {
     local output="$1"
     local phase="$2"
-    if ! grep -Fq 'String pool size after partial load' <<<"${output}"; then
+    if ! grep -Fq 'Header-only manifest load complete.' <<<"${output}"; then
         echo "${phase} did not complete a partial load:" >&2
         printf '%s\n' "${output}" >&2
         exit 1

--- a/dev_scripts/test_hf_cache_revalidation.sh
+++ b/dev_scripts/test_hf_cache_revalidation.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Verify that a stale cached HF manifest is revalidated and refetched.
+#
+# Usage: test_hf_cache_revalidation.sh [manifest-uri] [zelph-binary] [cache-root]
+#   manifest-uri: pruned Wikidata manifest on Hugging Face (default below)
+#   zelph-binary: built zelph executable (default: build-release/bin/zelph)
+#   cache-root:   disposable cache parent directory (default: /tmp/zelph-hf-cache-revalidation)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -6,6 +12,11 @@ ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
 MANIFEST="${1:-hf://datasets/acrion/zelph/wikidata-20260309-all-pruned/wikidata-20260309-all-pruned.hf-v2.json}"
 ZELPH="${2:-${ROOT}/build-release/bin/zelph}"
 CACHE="${3:-${TMPDIR:-/tmp}/zelph-hf-cache-revalidation}"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    sed -n '2,7p' "$0"
+    exit 0
+fi
 
 if [[ ! -x "${ZELPH}" ]]; then
     echo "zelph binary not executable: ${ZELPH}" >&2
@@ -17,11 +28,22 @@ mkdir -p "${CACHE}"
 
 run_load() {
     printf '.load-partial %s left=0 right=0 nameOfNode=0 nodeOfName=0\n.quit\n' "${MANIFEST}" \
-        | ZELPH_HF_CACHE_DIR="${CACHE}" "${ZELPH}" >/dev/null
+        | ZELPH_HF_CACHE_DIR="${CACHE}" "${ZELPH}" 2>&1
+}
+
+require_successful_load() {
+    local output="$1"
+    local phase="$2"
+    if ! grep -Fq 'String pool size after partial load' <<<"${output}"; then
+        echo "${phase} did not complete a partial load:" >&2
+        printf '%s\n' "${output}" >&2
+        exit 1
+    fi
 }
 
 echo "Initial remote load (populate cache)"
-run_load
+initial_output="$(run_load)"
+require_successful_load "${initial_output}" "Initial remote load"
 
 manifest_body="$(find "${CACHE}/v2" -maxdepth 1 -type f -name 'manifest_*.body' -print -quit)"
 if [[ -z "${manifest_body}" ]]; then
@@ -34,5 +56,10 @@ sed -i 's#"binPath"[[:space:]]*:[[:space:]]*"[^"]*"#"binPath": "/nonexistent/sta
 printf 'etag="tampered-by-hf-cache-regression"\n' >> "${manifest_body}.meta"
 
 echo "Second remote load (must revalidate and refetch)"
-run_load
+second_output="$(run_load)"
+require_successful_load "${second_output}" "Second remote load"
+if grep -Fq '/nonexistent/stale-local.bin' "${manifest_body}"; then
+    echo "Cached manifest still contains the tampered binPath after refetch" >&2
+    exit 1
+fi
 echo "HF cache revalidation regression passed"

--- a/dev_scripts/test_hf_cache_revalidation.sh
+++ b/dev_scripts/test_hf_cache_revalidation.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+MANIFEST="${1:-hf://datasets/acrion/zelph/wikidata-20260309-all-pruned/wikidata-20260309-all-pruned.hf-v2.json}"
+ZELPH="${2:-${ROOT}/build-release/bin/zelph}"
+CACHE="${3:-${TMPDIR:-/tmp}/zelph-hf-cache-revalidation}"
+
+if [[ ! -x "${ZELPH}" ]]; then
+    echo "zelph binary not executable: ${ZELPH}" >&2
+    exit 2
+fi
+
+rm -rf "${CACHE}"
+mkdir -p "${CACHE}"
+
+run_load() {
+    printf '.load-partial %s left=0 right=0 nameOfNode=0 nodeOfName=0\n.quit\n' "${MANIFEST}" \
+        | ZELPH_HF_CACHE_DIR="${CACHE}" "${ZELPH}" >/dev/null
+}
+
+echo "Initial remote load (populate cache)"
+run_load
+
+manifest_body="$(find "${CACHE}/v2" -maxdepth 1 -type f -name 'manifest_*.body' -print -quit)"
+if [[ -z "${manifest_body}" ]]; then
+    echo "No cached manifest body found under ${CACHE}/v2" >&2
+    exit 1
+fi
+
+echo "Tampering cached manifest and sidecar: ${manifest_body}"
+sed -i 's#"binPath"[[:space:]]*:[[:space:]]*"[^"]*"#"binPath": "/nonexistent/stale-local.bin"#' "${manifest_body}"
+printf 'etag="tampered-by-hf-cache-regression"\n' >> "${manifest_body}.meta"
+
+echo "Second remote load (must revalidate and refetch)"
+run_load
+echo "HF cache revalidation regression passed"

--- a/dev_scripts/test_hf_transfer_diagnostics.sh
+++ b/dev_scripts/test_hf_transfer_diagnostics.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Verify that a timed-out HF metadata probe fails promptly with a useful
+# diagnostic.  This is offline: it replaces curl with a fixture that emits the
+# same write-out JSON curl produces for exit code 28.
+#
+# Usage: test_hf_transfer_diagnostics.sh [zelph-binary] [cache-root]
+#   zelph-binary: built zelph executable (default: build-release/bin/zelph)
+#   cache-root:   disposable cache parent directory (default: /tmp/zelph-hf-transfer-diagnostics)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+ZELPH="${1:-${ROOT}/build-release/bin/zelph}"
+CACHE="${2:-${TMPDIR:-/tmp}/zelph-hf-transfer-diagnostics}"
+MANIFEST="hf://datasets/acrion/zelph/wikidata-20260309-all-pruned/wikidata-20260309-all-pruned.hf-v2.json"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    sed -n '2,7p' "$0"
+    exit 0
+fi
+if [[ ! -x "${ZELPH}" ]]; then
+    echo "zelph binary not executable: ${ZELPH}" >&2
+    exit 2
+fi
+
+rm -rf "${CACHE}"
+mkdir -p "${CACHE}/bin"
+FAKE_CURL="${CACHE}/bin/curl"
+cat > "${FAKE_CURL}" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"time_connect":0.001,"time_total":0.002,"size_download":0,"speed_download":0,"http_code":0,"exitcode":28}'
+exit 28
+EOF
+chmod +x "${FAKE_CURL}"
+
+output="$(printf '.load-partial %s meta-only\n.quit\n' "${MANIFEST}" \
+    | ZELPH_HF_CACHE_DIR="${CACHE}" ZELPH_HF_CURL_BIN="${FAKE_CURL}" "${ZELPH}" 2>&1 || true)"
+if ! grep -Fq 'HF probe response_timeout' <<<"${output}"; then
+    echo "Timed-out probe was not classified descriptively:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+fi
+if ! grep -Fq "${MANIFEST}" <<<"${output}"; then
+    echo "Diagnostic omitted the requested manifest URI:" >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+fi
+echo "HF transfer diagnostic regression passed"

--- a/mkdocs/docs/sharding.md
+++ b/mkdocs/docs/sharding.md
@@ -270,14 +270,17 @@ resolved object's ETag/repository revision before reuse. Shard and binary-range
 entries are keyed by the same remote identity plus their byte range, so a
 regenerated artifact cannot silently reuse ranges from an older dump. Set
 `ZELPH_HF_CACHE_DIR` to choose another cache root. If metadata validation is
-temporarily unavailable, an existing manifest may be reused with a diagnostic;
-payload objects require a validated remote identity before reuse.
+temporarily unavailable, zelph may reuse the most recently cached manifest for
+that exact source URI and emits a warning. Payload objects require a validated
+remote identity before reuse; use `shard-root=` for deliberate fully local or
+offline loading.
 
 The offline decision logic is covered by `src/test/test_hf_cache.cpp`. The
 network regression helper
-`dev_scripts/test_hf_cache_revalidation.sh` populates a cache, tampers with a
-cached manifest and its ETag, and verifies that the next remote load refetches
-the manifest.
+`dev_scripts/test_hf_cache_revalidation.sh [manifest-uri] [zelph-binary]
+[cache-root]` populates a disposable cache, tampers with a cached manifest and
+its ETag, and requires the next remote load to refetch the manifest and finish
+successfully. It does not modify the Hub.
 
 If you have already downloaded the shards (for example via `huggingface-cli download`), point `shard-root` at the local copy to skip network access:
 

--- a/mkdocs/docs/sharding.md
+++ b/mkdocs/docs/sharding.md
@@ -279,8 +279,45 @@ The offline decision logic is covered by `src/test/test_hf_cache.cpp`. The
 network regression helper
 `dev_scripts/test_hf_cache_revalidation.sh [manifest-uri] [zelph-binary]
 [cache-root]` populates a disposable cache, tampers with a cached manifest and
-its ETag, and requires the next remote load to refetch the manifest and finish
-successfully. It does not modify the Hub.
+its ETag, and requires the next remote header-only load to refetch the manifest
+and finish successfully. It does not modify the Hub or download a shard
+payload. The offline diagnostic helper
+`dev_scripts/test_hf_transfer_diagnostics.sh [zelph-binary] [cache-root]`
+uses a fake curl timeout and requires a URI-specific probe diagnostic.
+
+### Remote transfer limits and diagnostics
+
+Remote metadata probes and payload downloads use bounded `curl` calls. A
+probe has a connection deadline and a short total/retry budget. A payload has
+the same connection deadline, a no-progress deadline, and a byte-aware overall
+budget. The latter starts from a conservative per-host throughput estimate, so
+larger requested ranges receive more time without allowing a stuck process to
+wait indefinitely.
+
+Zelph records the completed call's operation, range, planned and received
+bytes, cache state, remote identity, DNS/connect/TLS/first-byte/total timings,
+average throughput, and outcome. A normal run prints only failures and slow
+successful transfers. Set `ZELPH_HF_TRANSFER_LOG` to a file path to retain one
+JSON-lines diagnostic record per call. The cache root retains a compact
+per-host throughput estimate from meaningful payloads for future byte-aware
+budgets.
+
+The defaults can be tuned for unusual networks:
+
+| Variable | Default | Meaning |
+| --- | ---: | --- |
+| `ZELPH_HF_CONNECT_TIMEOUT_SECONDS` | `15` | Maximum connection setup time per curl attempt. |
+| `ZELPH_HF_PROBE_TIMEOUT_SECONDS` | `45` | Total retry budget for a metadata probe. |
+| `ZELPH_HF_STALL_WINDOW_SECONDS` | `90` | Time below the minimum transfer rate before a payload is stalled. |
+| `ZELPH_HF_MIN_PROGRESS_BYTES_PER_SECOND` | `1024` | Minimum sustained payload rate used for the stall check. |
+| `ZELPH_HF_INITIAL_THROUGHPUT_BYTES_PER_SECOND` | `262144` | Initial per-host estimate before successful history exists. |
+
+The first implementation uses curl's end-of-call metrics and its native
+low-speed abort. It can classify a completed slow transfer and a curl-detected
+stall, but it does not yet sample live byte progress. A monitored-subprocess
+transport layer is the later extension for instantaneous throughput and exact
+last-progress timestamps; its measurements will also inform shard sizing and
+the planned progressive query/join executor.
 
 If you have already downloaded the shards (for example via `huggingface-cli download`), point `shard-root` at the local copy to skip network access:
 

--- a/mkdocs/docs/sharding.md
+++ b/mkdocs/docs/sharding.md
@@ -264,6 +264,21 @@ zelph> .load-partial hf://datasets/acrion/zelph/wikidata-20260309-all/wikidata-2
 
 zelph resolves the `hf://` paths to their HTTPS download URLs, fetches the manifest, fetches each requested shard, and caches everything locally so repeated loads are fast. For remote loading, the header is fetched from the source `.bin` using `source.headerLengthBytes`, so that field must be present in the manifest.
 
+Remote cache entries are stored under a versioned `v2` directory (by default
+`$TMPDIR/zelph-hf-cache/v2`). Manifest entries are revalidated through the
+resolved object's ETag/repository revision before reuse. Shard and binary-range
+entries are keyed by the same remote identity plus their byte range, so a
+regenerated artifact cannot silently reuse ranges from an older dump. Set
+`ZELPH_HF_CACHE_DIR` to choose another cache root. If metadata validation is
+temporarily unavailable, an existing manifest may be reused with a diagnostic;
+payload objects require a validated remote identity before reuse.
+
+The offline decision logic is covered by `src/test/test_hf_cache.cpp`. The
+network regression helper
+`dev_scripts/test_hf_cache_revalidation.sh` populates a cache, tampers with a
+cached manifest and its ETag, and verifies that the next remote load refetches
+the manifest.
+
 If you have already downloaded the shards (for example via `huggingface-cli download`), point `shard-root` at the local copy to skip network access:
 
 ```

--- a/src/lib/network/hf_cache.hpp
+++ b/src/lib/network/hf_cache.hpp
@@ -77,9 +77,10 @@ namespace zelph::network::detail::hf_cache
         }
         // A failed HEAD/resolve must not make an otherwise usable manifest
         // unavailable. Callers must emit a diagnostic when taking this path.
+        // A body without a valid sidecar is not an offline fallback candidate.
         if (!observed)
         {
-            return ReuseDecision::reuse_offline;
+            return cached ? ReuseDecision::reuse_offline : ReuseDecision::refetch;
         }
         return ReuseDecision::refetch;
     }

--- a/src/lib/network/hf_cache.hpp
+++ b/src/lib/network/hf_cache.hpp
@@ -1,0 +1,194 @@
+/*
+Copyright (c) 2026 acrion innovations GmbH
+
+Small, offline-testable policy layer for the Hugging Face remote cache.
+*/
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+
+namespace zelph::network::detail::hf_cache
+{
+    inline constexpr const char* cache_version = "v2";
+
+    struct RemoteMetadata
+    {
+        std::string source_uri;
+        std::string revision;
+        std::string etag;
+        uint64_t    content_length = 0;
+        int64_t     retrieved_at   = 0;
+    };
+
+    struct ObjectCoordinates
+    {
+        std::string source_uri;
+        std::string revision;
+        std::string etag;
+        uint64_t    offset = 0;
+        uint64_t    length = 0;
+    };
+
+    enum class ReuseDecision
+    {
+        refetch,
+        reuse,
+        reuse_offline,
+    };
+
+    inline bool has_identity(const RemoteMetadata& metadata)
+    {
+        return !metadata.revision.empty() || !metadata.etag.empty();
+    }
+
+    inline bool same_remote(const RemoteMetadata& a, const RemoteMetadata& b)
+    {
+        if (a.source_uri != b.source_uri || a.content_length != b.content_length)
+        {
+            return false;
+        }
+        if (!a.revision.empty() && !b.revision.empty() && a.revision != b.revision)
+        {
+            return false;
+        }
+        if (!a.etag.empty() && !b.etag.empty() && a.etag != b.etag)
+        {
+            return false;
+        }
+        return has_identity(a) && has_identity(b);
+    }
+
+    inline ReuseDecision decide_manifest(const bool body_exists,
+                                         const std::optional<RemoteMetadata>& cached,
+                                         const std::optional<RemoteMetadata>& observed)
+    {
+        if (!body_exists)
+        {
+            return ReuseDecision::refetch;
+        }
+        if (observed && cached && same_remote(*cached, *observed))
+        {
+            return ReuseDecision::reuse;
+        }
+        // A failed HEAD/resolve must not make an otherwise usable manifest
+        // unavailable. Callers must emit a diagnostic when taking this path.
+        if (!observed)
+        {
+            return ReuseDecision::reuse_offline;
+        }
+        return ReuseDecision::refetch;
+    }
+
+    inline ReuseDecision decide_object(const bool body_exists,
+                                       const std::optional<RemoteMetadata>& cached,
+                                       const ObjectCoordinates& requested)
+    {
+        if (!body_exists || !cached)
+        {
+            return ReuseDecision::refetch;
+        }
+
+        // The sidecar stores the full remote object's Content-Length, while
+        // `requested.length` is only this range's length.  Range identity is
+        // part of the filename; compare the remote identity here.
+        if (cached->source_uri == requested.source_uri
+            && (cached->revision.empty() || requested.revision.empty() || cached->revision == requested.revision)
+            && (cached->etag.empty() || requested.etag.empty() || cached->etag == requested.etag)
+            && has_identity(*cached))
+        {
+            return ReuseDecision::reuse;
+        }
+        return ReuseDecision::refetch;
+    }
+
+    inline std::string escape_field(std::string value)
+    {
+        for (size_t pos = 0; (pos = value.find('\\', pos)) != std::string::npos; pos += 2)
+        {
+            value.replace(pos, 1, "\\\\");
+        }
+        for (size_t pos = 0; (pos = value.find('\n', pos)) != std::string::npos; pos += 2)
+        {
+            value.replace(pos, 1, "\\n");
+        }
+        return value;
+    }
+
+    inline std::string unescape_field(std::string value)
+    {
+        for (size_t pos = 0; (pos = value.find("\\\\", pos)) != std::string::npos;)
+        {
+            value.replace(pos, 2, "\\");
+            ++pos;
+        }
+        for (size_t pos = 0; (pos = value.find("\\n", pos)) != std::string::npos;)
+        {
+            value.replace(pos, 2, "\n");
+            ++pos;
+        }
+        return value;
+    }
+
+    inline bool write_sidecar(const std::filesystem::path& path, const RemoteMetadata& metadata)
+    {
+        std::ofstream out(path, std::ios::trunc);
+        if (!out)
+        {
+            return false;
+        }
+        out << "version=" << cache_version << '\n'
+            << "source_uri=" << escape_field(metadata.source_uri) << '\n'
+            << "revision=" << escape_field(metadata.revision) << '\n'
+            << "etag=" << escape_field(metadata.etag) << '\n'
+            << "content_length=" << metadata.content_length << '\n'
+            << "retrieved_at=" << metadata.retrieved_at << '\n';
+        return static_cast<bool>(out);
+    }
+
+    inline std::optional<RemoteMetadata> read_sidecar(const std::filesystem::path& path)
+    {
+        std::ifstream in(path);
+        if (!in)
+        {
+            return std::nullopt;
+        }
+
+        RemoteMetadata metadata;
+        std::string version;
+        std::string line;
+        while (std::getline(in, line))
+        {
+            const auto equals = line.find('=');
+            if (equals == std::string::npos)
+            {
+                continue;
+            }
+            const auto key   = line.substr(0, equals);
+            const auto value = line.substr(equals + 1);
+            if (key == "version") version = value;
+            else if (key == "source_uri") metadata.source_uri = unescape_field(value);
+            else if (key == "revision") metadata.revision = unescape_field(value);
+            else if (key == "etag") metadata.etag = unescape_field(value);
+            else if (key == "content_length")
+            {
+                try { metadata.content_length = std::stoull(value); }
+                catch (...) { return std::nullopt; }
+            }
+            else if (key == "retrieved_at")
+            {
+                try { metadata.retrieved_at = std::stoll(value); }
+                catch (...) { return std::nullopt; }
+            }
+        }
+        if (version != cache_version || metadata.source_uri.empty())
+        {
+            return std::nullopt;
+        }
+        return metadata;
+    }
+}

--- a/src/lib/network/hf_transfer.hpp
+++ b/src/lib/network/hf_transfer.hpp
@@ -1,0 +1,429 @@
+/*
+Copyright (c) 2026 acrion innovations GmbH
+
+Bounded, observable curl transport for Hugging Face cache fetches.
+*/
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+
+namespace zelph::network::detail::hf_transfer
+{
+    inline constexpr const char* host_stats_version = "v1";
+
+    enum class Operation
+    {
+        probe,
+        fetch,
+    };
+
+    struct Limits
+    {
+        uint64_t connect_timeout_seconds             = 15;
+        uint64_t probe_timeout_seconds               = 45;
+        uint64_t stall_window_seconds                = 90;
+        uint64_t min_progress_bytes_per_second       = 1024;
+        uint64_t initial_throughput_bytes_per_second = 262144;
+    };
+
+    struct HostStats
+    {
+        std::string host;
+        uint64_t    throughput_bytes_per_second = 0;
+        uint64_t    samples                     = 0;
+    };
+
+    struct Request
+    {
+        Operation   operation = Operation::fetch;
+        std::string source_uri;
+        std::string url;
+        std::string output_path;
+        std::string header_path;
+        std::string metrics_path;
+        std::string revision;
+        std::string etag;
+        uint64_t    offset        = 0;
+        uint64_t    planned_bytes = 0;
+    };
+
+    struct Metrics
+    {
+        uint64_t dns_milliseconds         = 0;
+        uint64_t connect_milliseconds     = 0;
+        uint64_t tls_milliseconds         = 0;
+        uint64_t first_byte_milliseconds  = 0;
+        uint64_t total_milliseconds       = 0;
+        uint64_t received_bytes           = 0;
+        uint64_t average_bytes_per_second = 0;
+        uint64_t http_status              = 0;
+        uint64_t curl_exit                = 0;
+    };
+
+    enum class Outcome
+    {
+        completed,
+        slow_completed,
+        connection_timeout,
+        response_timeout,
+        stalled,
+        transfer_deadline,
+        failed_http,
+        failed_curl,
+    };
+
+    inline const char* operation_name(const Operation operation)
+    {
+        return operation == Operation::probe ? "probe" : "fetch";
+    }
+
+    inline const char* outcome_name(const Outcome outcome)
+    {
+        switch (outcome)
+        {
+        case Outcome::completed:
+            return "completed";
+        case Outcome::slow_completed:
+            return "slow_completed";
+        case Outcome::connection_timeout:
+            return "connection_timeout";
+        case Outcome::response_timeout:
+            return "response_timeout";
+        case Outcome::stalled:
+            return "stalled";
+        case Outcome::transfer_deadline:
+            return "transfer_deadline";
+        case Outcome::failed_http:
+            return "failed_http";
+        case Outcome::failed_curl:
+            return "failed_curl";
+        }
+        return "failed_curl";
+    }
+
+    inline uint64_t environment_uint64(const char* name, const uint64_t fallback)
+    {
+        const char* value = std::getenv(name);
+        if (!value || !*value)
+        {
+            return fallback;
+        }
+        try
+        {
+            const auto parsed = std::stoull(value);
+            return parsed > 0 ? parsed : fallback;
+        }
+        catch (...)
+        {
+            return fallback;
+        }
+    }
+
+    inline Limits limits_from_environment()
+    {
+        Limits limits;
+        limits.connect_timeout_seconds       = environment_uint64("ZELPH_HF_CONNECT_TIMEOUT_SECONDS", limits.connect_timeout_seconds);
+        limits.probe_timeout_seconds         = environment_uint64("ZELPH_HF_PROBE_TIMEOUT_SECONDS", limits.probe_timeout_seconds);
+        limits.stall_window_seconds          = environment_uint64("ZELPH_HF_STALL_WINDOW_SECONDS", limits.stall_window_seconds);
+        limits.min_progress_bytes_per_second = environment_uint64(
+            "ZELPH_HF_MIN_PROGRESS_BYTES_PER_SECOND", limits.min_progress_bytes_per_second);
+        limits.initial_throughput_bytes_per_second = environment_uint64(
+            "ZELPH_HF_INITIAL_THROUGHPUT_BYTES_PER_SECOND", limits.initial_throughput_bytes_per_second);
+        return limits;
+    }
+
+    inline std::string shell_quote(const std::string& value)
+    {
+        std::string out = "'";
+        for (const char c : value)
+        {
+            if (c == '\'')
+                out += "'\"'\"'";
+            else
+                out.push_back(c);
+        }
+        out += "'";
+        return out;
+    }
+
+    inline std::string curl_binary_from_environment()
+    {
+        const char* configured = std::getenv("ZELPH_HF_CURL_BIN");
+        return configured && *configured ? configured : "curl";
+    }
+
+    inline std::string host_from_url(const std::string& url)
+    {
+        const auto scheme = url.find("://");
+        const auto start  = scheme == std::string::npos ? 0 : scheme + 3;
+        const auto end    = url.find('/', start);
+        return url.substr(start, end == std::string::npos ? std::string::npos : end - start);
+    }
+
+    inline std::string stable_token(const std::string& value)
+    {
+        uint64_t hash = 1469598103934665603ULL;
+        for (const unsigned char byte : value)
+        {
+            hash ^= byte;
+            hash *= 1099511628211ULL;
+        }
+        return std::to_string(hash);
+    }
+
+    inline std::filesystem::path host_stats_path(const std::filesystem::path& cache_root, const std::string& host)
+    {
+        return cache_root / ("transfer-host_" + stable_token(host) + ".meta");
+    }
+
+    inline std::optional<HostStats> read_host_stats(const std::filesystem::path& path)
+    {
+        std::ifstream input(path);
+        if (!input)
+        {
+            return std::nullopt;
+        }
+        std::string version;
+        HostStats   stats;
+        std::string line;
+        while (std::getline(input, line))
+        {
+            const auto equals = line.find('=');
+            if (equals == std::string::npos) continue;
+            const auto key   = line.substr(0, equals);
+            const auto value = line.substr(equals + 1);
+            try
+            {
+                if (key == "version")
+                    version = value;
+                else if (key == "host")
+                    stats.host = value;
+                else if (key == "throughput_bytes_per_second")
+                    stats.throughput_bytes_per_second = std::stoull(value);
+                else if (key == "samples")
+                    stats.samples = std::stoull(value);
+            }
+            catch (...)
+            {
+                return std::nullopt;
+            }
+        }
+        if (version != host_stats_version || stats.host.empty() || stats.throughput_bytes_per_second == 0)
+        {
+            return std::nullopt;
+        }
+        return stats;
+    }
+
+    inline bool write_host_stats(const std::filesystem::path& path, const HostStats& stats)
+    {
+        std::ofstream output(path, std::ios::trunc);
+        if (!output) return false;
+        output << "version=" << host_stats_version << '\n'
+               << "host=" << stats.host << '\n'
+               << "throughput_bytes_per_second=" << stats.throughput_bytes_per_second << '\n'
+               << "samples=" << stats.samples << '\n';
+        return static_cast<bool>(output);
+    }
+
+    inline uint64_t conservative_rate(const std::optional<HostStats>& stats, const Limits& limits)
+    {
+        constexpr uint64_t minimum  = 64 * 1024;
+        constexpr uint64_t maximum  = 32 * 1024 * 1024;
+        const uint64_t     baseline = stats ? stats->throughput_bytes_per_second / 4
+                                            : limits.initial_throughput_bytes_per_second;
+        return std::clamp(baseline, minimum, maximum);
+    }
+
+    inline uint64_t payload_timeout_seconds(const uint64_t planned_bytes,
+                                            const uint64_t rate,
+                                            const Limits&  limits)
+    {
+        const uint64_t transfer_seconds = planned_bytes == 0 ? 0 : (planned_bytes + rate - 1) / rate;
+        return std::max<uint64_t>(limits.stall_window_seconds + limits.connect_timeout_seconds,
+                                  uint64_t{45} + (uint64_t{4} * transfer_seconds));
+    }
+
+    inline std::string build_curl_command(const Request& request,
+                                          const Limits&  limits,
+                                          const uint64_t rate)
+    {
+        const uint64_t max_time = request.operation == Operation::probe
+                                    ? limits.probe_timeout_seconds
+                                    : payload_timeout_seconds(request.planned_bytes, rate, limits);
+        std::string    command  = shell_quote(curl_binary_from_environment()) + " -fsSL --retry 2 --connect-timeout "
+                                + std::to_string(limits.connect_timeout_seconds)
+                                + " --max-time " + std::to_string(max_time);
+        if (request.operation == Operation::probe)
+        {
+            command += " -I --retry-max-time " + std::to_string(limits.probe_timeout_seconds)
+                     + " -o /dev/null -D " + shell_quote(request.header_path);
+        }
+        else
+        {
+            command += " --speed-limit " + std::to_string(limits.min_progress_bytes_per_second)
+                     + " --speed-time " + std::to_string(limits.stall_window_seconds);
+            if (request.planned_bytes > 0)
+            {
+                command += " --range " + std::to_string(request.offset) + "-"
+                         + std::to_string(request.offset + request.planned_bytes - 1);
+            }
+            command += " -o " + shell_quote(request.output_path);
+        }
+        command += " --write-out " + shell_quote("%{json}\\n") + " " + shell_quote(request.url)
+                 + " > " + shell_quote(request.metrics_path);
+        return command;
+    }
+
+    inline std::optional<double> json_number(const std::string& body, const std::string& key)
+    {
+        const auto marker = '"' + key + '"';
+        auto       pos    = body.find(marker);
+        if (pos == std::string::npos) return std::nullopt;
+        pos = body.find(':', pos + marker.size());
+        if (pos == std::string::npos) return std::nullopt;
+        ++pos;
+        while (pos < body.size() && std::isspace(static_cast<unsigned char>(body[pos])))
+            ++pos;
+        const auto end  = body.find_first_of(",}", pos);
+        const auto text = body.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+        if (text == "null" || text.empty()) return std::nullopt;
+        try
+        {
+            return std::stod(text);
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
+    }
+
+    inline uint64_t milliseconds(const std::optional<double>& seconds)
+    {
+        return seconds ? static_cast<uint64_t>(std::llround(*seconds * 1000.0)) : 0;
+    }
+
+    inline std::optional<Metrics> read_metrics(const std::filesystem::path& path)
+    {
+        std::ifstream input(path);
+        if (!input) return std::nullopt;
+        std::stringstream buffer;
+        buffer << input.rdbuf();
+        const auto body = buffer.str();
+        if (body.empty()) return std::nullopt;
+        Metrics metrics;
+        metrics.dns_milliseconds         = milliseconds(json_number(body, "time_namelookup"));
+        metrics.connect_milliseconds     = milliseconds(json_number(body, "time_connect"));
+        metrics.tls_milliseconds         = milliseconds(json_number(body, "time_appconnect"));
+        metrics.first_byte_milliseconds  = milliseconds(json_number(body, "time_starttransfer"));
+        metrics.total_milliseconds       = milliseconds(json_number(body, "time_total"));
+        metrics.received_bytes           = static_cast<uint64_t>(json_number(body, "size_download").value_or(0.0));
+        metrics.average_bytes_per_second = static_cast<uint64_t>(json_number(body, "speed_download").value_or(0.0));
+        metrics.http_status              = static_cast<uint64_t>(json_number(body, "http_code").value_or(0.0));
+        metrics.curl_exit                = static_cast<uint64_t>(json_number(body, "exitcode").value_or(0.0));
+        return metrics;
+    }
+
+    inline Outcome classify(const Request& request, const Metrics& metrics, const uint64_t conservative_bytes_per_second)
+    {
+        if (metrics.curl_exit == 0)
+        {
+            if (request.operation == Operation::fetch && request.planned_bytes >= 64 * 1024
+                && metrics.average_bytes_per_second > 0
+                && metrics.average_bytes_per_second < conservative_bytes_per_second / 2)
+            {
+                return Outcome::slow_completed;
+            }
+            return Outcome::completed;
+        }
+        if (metrics.http_status >= 400) return Outcome::failed_http;
+        if (metrics.curl_exit == 28)
+        {
+            if (metrics.connect_milliseconds == 0) return Outcome::connection_timeout;
+            if (metrics.received_bytes == 0) return Outcome::response_timeout;
+            if (request.operation == Operation::fetch
+                && metrics.average_bytes_per_second < conservative_bytes_per_second / 2)
+            {
+                return Outcome::stalled;
+            }
+            return Outcome::transfer_deadline;
+        }
+        return Outcome::failed_curl;
+    }
+
+    inline void update_host_stats(const std::filesystem::path& cache_root,
+                                  const std::string&           host,
+                                  const uint64_t               planned_bytes,
+                                  const Metrics&               metrics)
+    {
+        // Header reads and tiny objects are dominated by latency. Retain their
+        // per-call diagnostics, but do not let them shrink a shard budget.
+        if (planned_bytes < 64 * 1024 || metrics.curl_exit != 0 || metrics.average_bytes_per_second == 0) return;
+        const auto     path  = host_stats_path(cache_root, host);
+        const auto     prior = read_host_stats(path);
+        const uint64_t rate  = prior
+                                 ? (prior->throughput_bytes_per_second * 4 + metrics.average_bytes_per_second) / 5
+                                 : metrics.average_bytes_per_second;
+        write_host_stats(path, {host, rate, prior ? prior->samples + 1 : 1});
+    }
+
+    inline std::string json_escape(const std::string& value)
+    {
+        std::string escaped;
+        for (const char c : value)
+        {
+            if (c == '\n')
+            {
+                escaped += "\\n";
+            }
+            else
+            {
+                if (c == '"' || c == '\\') escaped.push_back('\\');
+                escaped.push_back(c);
+            }
+        }
+        return escaped;
+    }
+
+    inline void append_diagnostic(const Request&     request,
+                                  const Metrics&     metrics,
+                                  const Outcome      outcome,
+                                  const std::string& cache_state)
+    {
+        const char* configured = std::getenv("ZELPH_HF_TRANSFER_LOG");
+        if (!configured || !*configured) return;
+        std::ofstream output(configured, std::ios::app);
+        if (!output) return;
+        const auto recorded_at = std::chrono::duration_cast<std::chrono::seconds>(
+                                     std::chrono::system_clock::now().time_since_epoch())
+                                     .count();
+        output << "{\"recorded_at_epoch_seconds\":" << recorded_at
+               << ",\"operation\":\"" << operation_name(request.operation)
+               << "\",\"outcome\":\"" << outcome_name(outcome)
+               << "\",\"source_uri\":\"" << json_escape(request.source_uri)
+               << "\",\"offset\":" << request.offset
+               << ",\"planned_bytes\":" << request.planned_bytes
+               << ",\"received_bytes\":" << metrics.received_bytes
+               << ",\"average_bytes_per_second\":" << metrics.average_bytes_per_second
+               << ",\"dns_milliseconds\":" << metrics.dns_milliseconds
+               << ",\"connect_milliseconds\":" << metrics.connect_milliseconds
+               << ",\"tls_milliseconds\":" << metrics.tls_milliseconds
+               << ",\"first_byte_milliseconds\":" << metrics.first_byte_milliseconds
+               << ",\"total_milliseconds\":" << metrics.total_milliseconds
+               << ",\"http_status\":" << metrics.http_status
+               << ",\"curl_exit\":" << metrics.curl_exit
+               << ",\"cache_state\":\"" << json_escape(cache_state)
+               << "\",\"revision\":\"" << json_escape(request.revision)
+               << "\",\"etag\":\"" << json_escape(request.etag) << "\"}\n";
+    }
+}

--- a/src/lib/network/manifest_loader.hpp
+++ b/src/lib/network/manifest_loader.hpp
@@ -1151,7 +1151,7 @@ namespace zelph::network
                     continue;
                 }
                 const auto metadata = hf_cache::read_sidecar(entry.path().string() + ".meta");
-                if (metadata && metadata->retrieved_at >= best_time)
+                if (metadata && metadata->source_uri == source && metadata->retrieved_at >= best_time)
                 {
                     best_time = metadata->retrieved_at;
                     best = entry.path();
@@ -1172,11 +1172,16 @@ namespace zelph::network
                 throw std::runtime_error("Expected remote source for cached fetch: " + source);
             }
 
-            auto observed = probe_remote(source);
-            if (!observed && section_hint == "manifest")
+            const bool manifest_request = section_hint == "manifest";
+            auto       observed         = probe_remote(source);
+            if (!observed && manifest_request)
             {
                 const auto offline = offline_manifest_candidate(source);
-                if (!offline.empty())
+                const auto cached  = offline.empty()
+                                   ? std::optional<hf_cache::RemoteMetadata>{}
+                                   : hf_cache::read_sidecar(offline.string() + ".meta");
+                if (hf_cache::decide_manifest(!offline.empty(), cached, std::nullopt)
+                    == hf_cache::ReuseDecision::reuse_offline)
                 {
                     std::fprintf(stderr, "zelph: warning: using cached manifest while remote metadata is unavailable: %s\n", source.c_str());
                     return offline;
@@ -1190,12 +1195,18 @@ namespace zelph::network
 
             const std::string identity = source + "\n" + observed->revision + "\n" + observed->etag;
             const std::string token = sanitize_cache_token(section_hint);
-            const std::string key = cache_hash(identity);
-            fs::path cache_file = ensure_cache_dir() / fs::path(token + "_" + key + "_" + std::to_string(offset) + "_" + std::to_string(length) + ".body");
+            const std::string source_key = cache_hash(source);
+            const std::string identity_key = cache_hash(identity);
+            fs::path cache_file = ensure_cache_dir()
+                                / fs::path(token + "_" + source_key + "_" + identity_key + "_"
+                                           + std::to_string(offset) + "_" + std::to_string(length) + ".body");
             const auto sidecar = cache_file.string() + ".meta";
             const auto cached = hf_cache::read_sidecar(sidecar);
             hf_cache::ObjectCoordinates coordinates{source, observed->revision, observed->etag, offset, length};
-            if (hf_cache::decide_object(fs::exists(cache_file), cached, coordinates) == hf_cache::ReuseDecision::reuse
+            const auto decision = manifest_request
+                                ? hf_cache::decide_manifest(fs::exists(cache_file), cached, observed)
+                                : hf_cache::decide_object(fs::exists(cache_file), cached, coordinates);
+            if (decision == hf_cache::ReuseDecision::reuse
                 && (length == 0 || fs::file_size(cache_file) == length))
             {
                 return cache_file;

--- a/src/lib/network/manifest_loader.hpp
+++ b/src/lib/network/manifest_loader.hpp
@@ -40,6 +40,7 @@ along with zelph. If not, see <https://www.gnu.org/licenses/>.
 
 #include "zelph.hpp"
 #include "hf_cache.hpp"
+#include "hf_transfer.hpp"
 
 namespace zelph::network
 {
@@ -300,24 +301,6 @@ namespace zelph::network
         inline bool is_hf_uri(const std::string& source)
         {
             return source.rfind("hf://", 0) == 0 || source.rfind("http://", 0) == 0 || source.rfind("https://", 0) == 0;
-        }
-
-        inline std::string quote_shell_token(const std::string& value)
-        {
-            std::string out = "'";
-            for (char c : value)
-            {
-                if (c == '\'')
-                {
-                    out += "'\"'\"'";
-                }
-                else
-                {
-                    out.push_back(c);
-                }
-            }
-            out += "'";
-            return out;
         }
 
         inline std::string hf_path_to_http_url(const std::string& hf_path)
@@ -1070,22 +1053,96 @@ namespace zelph::network
                 .count();
         }
 
+        inline hf_transfer::Metrics run_bounded_remote_transfer(
+            const hf_transfer::Operation operation,
+            const std::string&           source,
+            const std::string&           url,
+            const std::string&           output_path,
+            const std::string&           header_path,
+            const uint64_t               offset,
+            const uint64_t               planned_bytes,
+            const std::string&           revision,
+            const std::string&           etag,
+            const std::string&           cache_state)
+        {
+            namespace fs                            = std::filesystem;
+            const auto                 root         = ensure_cache_dir();
+            const auto                 metrics_path = root / ("transfer_" + cache_hash(source + "\n" + std::to_string(offset) + "\n" + std::to_string(planned_bytes)) + ".json");
+            const auto                 limits       = hf_transfer::limits_from_environment();
+            const auto                 host         = hf_transfer::host_from_url(url);
+            const auto                 stats        = hf_transfer::read_host_stats(hf_transfer::host_stats_path(root, host));
+            const auto                 rate         = hf_transfer::conservative_rate(stats, limits);
+            const hf_transfer::Request request{operation, source, url, output_path, header_path, metrics_path.string(), revision, etag, offset, planned_bytes};
+            const auto                 command = hf_transfer::build_curl_command(request, limits, rate);
+
+            std::string command_error;
+            try
+            {
+                run_shell_command(command);
+            }
+            catch (const std::exception& error)
+            {
+                command_error = error.what();
+            }
+
+            auto            metrics = hf_transfer::read_metrics(metrics_path);
+            std::error_code ignored;
+            fs::remove(metrics_path, ignored);
+            if (!metrics)
+            {
+                throw std::runtime_error("HF " + std::string(hf_transfer::operation_name(operation))
+                                         + " produced no transfer metrics for " + source
+                                         + (command_error.empty() ? "" : ": " + command_error));
+            }
+            if (!command_error.empty() && metrics->curl_exit == 0)
+            {
+                // Older curl versions may omit exitcode from %{json}; the
+                // shell status remains authoritative in that case.
+                metrics->curl_exit = 1;
+            }
+
+            const auto outcome = hf_transfer::classify(request, *metrics, rate);
+            hf_transfer::append_diagnostic(request, *metrics, outcome, cache_state);
+            hf_transfer::update_host_stats(root, host, planned_bytes, *metrics);
+            if (outcome == hf_transfer::Outcome::completed)
+            {
+                return *metrics;
+            }
+            if (outcome == hf_transfer::Outcome::slow_completed)
+            {
+                std::fprintf(stderr,
+                             "zelph: warning: HF fetch completed slowly: %s (%llu bytes in %llums, %llu B/s)\n",
+                             source.c_str(),
+                             static_cast<unsigned long long>(metrics->received_bytes),
+                             static_cast<unsigned long long>(metrics->total_milliseconds),
+                             static_cast<unsigned long long>(metrics->average_bytes_per_second));
+                return *metrics;
+            }
+
+            throw std::runtime_error("HF " + std::string(hf_transfer::operation_name(operation)) + " "
+                                     + hf_transfer::outcome_name(outcome) + " for " + source
+                                     + " (planned=" + std::to_string(planned_bytes)
+                                     + " bytes, received=" + std::to_string(metrics->received_bytes)
+                                     + " bytes, elapsed=" + std::to_string(metrics->total_milliseconds)
+                                     + "ms, curl_exit=" + std::to_string(metrics->curl_exit) + ")"
+                                     + (command_error.empty() ? "" : ": " + command_error));
+        }
+
         inline std::optional<hf_cache::RemoteMetadata> probe_remote(const std::string& source)
         {
             namespace fs = std::filesystem;
             const auto root = ensure_cache_dir();
             const auto header_path = root / ("probe_" + cache_hash(source) + ".headers");
             const auto url = hf_path_to_http_url(source);
-            const auto command = "curl -fsSLI --retry 2 " + quote_shell_token(url) + " -o /dev/null -D "
-                               + quote_shell_token(header_path.string());
             try
             {
-                run_shell_command(command);
+                run_bounded_remote_transfer(hf_transfer::Operation::probe, source, url, {}, header_path.string(), 0, 0, {}, {}, "revalidate");
             }
-            catch (...)
+            catch (const std::exception& error)
             {
                 std::error_code ignored;
                 fs::remove(header_path, ignored);
+                std::fprintf(stderr, "zelph: warning: HF probe unavailable for %s: %s\n", source.c_str(), error.what());
                 return std::nullopt;
             }
 
@@ -1214,13 +1271,7 @@ namespace zelph::network
 
             const std::string url = hf_path_to_http_url(source);
 
-            std::string range_arg;
-            if (length > 0)
-            {
-                range_arg = " --range " + std::to_string(offset) + "-" + std::to_string(offset + length - 1);
-            }
-            const std::string cmd = "curl -fsSL" + range_arg + " " + quote_shell_token(url) + " -o " + quote_shell_token(cache_file.string());
-            run_shell_command(cmd);
+            run_bounded_remote_transfer(hf_transfer::Operation::fetch, source, url, cache_file.string(), {}, offset, length, observed->revision, observed->etag, "refetch");
 
             if (length > 0 && fs::file_size(cache_file) != length)
             {

--- a/src/lib/network/manifest_loader.hpp
+++ b/src/lib/network/manifest_loader.hpp
@@ -31,12 +31,15 @@ along with zelph. If not, see <https://www.gnu.org/licenses/>.
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <chrono>
+#include <cstdlib>
 #include <string>
 #include <string_view>
 #include <unordered_set>
 #include <vector>
 
 #include "zelph.hpp"
+#include "hf_cache.hpp"
 
 namespace zelph::network
 {
@@ -1018,7 +1021,10 @@ namespace zelph::network
         inline std::filesystem::path ensure_cache_dir()
         {
             namespace fs        = std::filesystem;
-            fs::path cache_root = fs::temp_directory_path() / "zelph-hf-cache";
+            const char* configured_root = std::getenv("ZELPH_HF_CACHE_DIR");
+            fs::path cache_root = (configured_root && *configured_root)
+                                ? fs::path(configured_root) / hf_cache::cache_version
+                                : fs::temp_directory_path() / "zelph-hf-cache" / hf_cache::cache_version;
             if (!fs::exists(cache_root))
             {
                 fs::create_directories(cache_root);
@@ -1044,6 +1050,116 @@ namespace zelph::network
             return token;
         }
 
+        inline std::string cache_hash(const std::string& value)
+        {
+            // Stable across processes and platforms; this is a cache token,
+            // not a cryptographic content digest.
+            uint64_t hash = 1469598103934665603ULL;
+            for (unsigned char byte : value)
+            {
+                hash ^= byte;
+                hash *= 1099511628211ULL;
+            }
+            return std::to_string(hash);
+        }
+
+        inline int64_t cache_now()
+        {
+            return std::chrono::duration_cast<std::chrono::seconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                .count();
+        }
+
+        inline std::optional<hf_cache::RemoteMetadata> probe_remote(const std::string& source)
+        {
+            namespace fs = std::filesystem;
+            const auto root = ensure_cache_dir();
+            const auto header_path = root / ("probe_" + cache_hash(source) + ".headers");
+            const auto url = hf_path_to_http_url(source);
+            const auto command = "curl -fsSLI --retry 2 " + quote_shell_token(url) + " -o /dev/null -D "
+                               + quote_shell_token(header_path.string());
+            try
+            {
+                run_shell_command(command);
+            }
+            catch (...)
+            {
+                std::error_code ignored;
+                fs::remove(header_path, ignored);
+                return std::nullopt;
+            }
+
+            std::ifstream headers(header_path);
+            if (!headers)
+            {
+                return std::nullopt;
+            }
+
+            hf_cache::RemoteMetadata metadata;
+            metadata.source_uri = source;
+            std::string line;
+            while (std::getline(headers, line))
+            {
+                if (line.rfind("HTTP/", 0) == 0)
+                {
+                    // Redirects can produce multiple header blocks; the last
+                    // block is the resolved object.
+                    metadata.revision.clear();
+                    metadata.etag.clear();
+                    metadata.content_length = 0;
+                    continue;
+                }
+                const auto colon = line.find(':');
+                if (colon == std::string::npos)
+                {
+                    continue;
+                }
+                std::string key = line.substr(0, colon);
+                for (char& c : key) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+                std::string value = line.substr(colon + 1);
+                while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front()))) value.erase(value.begin());
+                while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back()))) value.pop_back();
+                if (key == "etag") metadata.etag = value;
+                else if (key == "x-repo-commit") metadata.revision = value;
+                else if (key == "content-length")
+                {
+                    try { metadata.content_length = std::stoull(value); } catch (...) { metadata.content_length = 0; }
+                }
+            }
+            metadata.retrieved_at = cache_now();
+            std::error_code ignored;
+            fs::remove(header_path, ignored);
+            if (!hf_cache::has_identity(metadata))
+            {
+                return std::nullopt;
+            }
+            return metadata;
+        }
+
+        inline std::filesystem::path offline_manifest_candidate(const std::string& source)
+        {
+            namespace fs = std::filesystem;
+            const auto root = ensure_cache_dir();
+            const auto prefix = "manifest_" + cache_hash(source) + "_";
+            fs::path best;
+            int64_t best_time = -1;
+            for (const auto& entry : fs::directory_iterator(root))
+            {
+                const auto name = entry.path().filename().string();
+                if (name.rfind(prefix, 0) != 0 || name.find(".body") == std::string::npos)
+                {
+                    continue;
+                }
+                const auto metadata = hf_cache::read_sidecar(entry.path().string() + ".meta");
+                if (metadata && metadata->retrieved_at >= best_time)
+                {
+                    best_time = metadata->retrieved_at;
+                    best = entry.path();
+                }
+            }
+            return best;
+        }
+
         inline std::filesystem::path fetch_chunk_to_cache(const std::string& source,
                                                           const uint64_t     offset,
                                                           const uint64_t     length,
@@ -1051,21 +1167,38 @@ namespace zelph::network
         {
             namespace fs = std::filesystem;
 
-            std::string token      = sanitize_cache_token(section_hint);
-            std::string src_token  = sanitize_cache_token(source);
-            fs::path    cache_file = ensure_cache_dir() / fs::path(token + "_" + src_token + "_" + std::to_string(offset) + "_" + std::to_string(length) + ".capnp-packed");
-
-            if (fs::exists(cache_file))
-            {
-                if (length == 0 || fs::file_size(cache_file) == length)
-                {
-                    return cache_file;
-                }
-            }
-
             if (!is_hf_uri(source) && !source.empty() && source.rfind("file://", 0) != 0)
             {
                 throw std::runtime_error("Expected remote source for cached fetch: " + source);
+            }
+
+            auto observed = probe_remote(source);
+            if (!observed && section_hint == "manifest")
+            {
+                const auto offline = offline_manifest_candidate(source);
+                if (!offline.empty())
+                {
+                    std::fprintf(stderr, "zelph: warning: using cached manifest while remote metadata is unavailable: %s\n", source.c_str());
+                    return offline;
+                }
+            }
+
+            if (!observed)
+            {
+                throw std::runtime_error("Unable to validate remote cache identity for " + source);
+            }
+
+            const std::string identity = source + "\n" + observed->revision + "\n" + observed->etag;
+            const std::string token = sanitize_cache_token(section_hint);
+            const std::string key = cache_hash(identity);
+            fs::path cache_file = ensure_cache_dir() / fs::path(token + "_" + key + "_" + std::to_string(offset) + "_" + std::to_string(length) + ".body");
+            const auto sidecar = cache_file.string() + ".meta";
+            const auto cached = hf_cache::read_sidecar(sidecar);
+            hf_cache::ObjectCoordinates coordinates{source, observed->revision, observed->etag, offset, length};
+            if (hf_cache::decide_object(fs::exists(cache_file), cached, coordinates) == hf_cache::ReuseDecision::reuse
+                && (length == 0 || fs::file_size(cache_file) == length))
+            {
+                return cache_file;
             }
 
             const std::string url = hf_path_to_http_url(source);
@@ -1082,6 +1215,12 @@ namespace zelph::network
             {
                 throw std::runtime_error("Downloaded chunk size mismatch for " + source + ", expected " + std::to_string(length)
                                          + ", got " + std::to_string(fs::file_size(cache_file)));
+            }
+
+            observed->retrieved_at = cache_now();
+            if (!hf_cache::write_sidecar(sidecar, *observed))
+            {
+                std::fprintf(stderr, "zelph: warning: could not write cache metadata: %s\n", sidecar.c_str());
             }
 
             return cache_file;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(zelph_tests
     test_sparql.cpp
     test_stratified.cpp
     test_wikidata_qualifiers.cpp
+    test_hf_cache.cpp
 )
 target_link_libraries(zelph_tests PRIVATE zelph_lib doctest_with_main)
 

--- a/src/test/test_hf_cache.cpp
+++ b/src/test/test_hf_cache.cpp
@@ -22,6 +22,7 @@ TEST_CASE("HF manifest cache revalidates identities")
     CHECK(decide_manifest(true, cached, current) == ReuseDecision::refetch);
     CHECK(decide_manifest(true, cached, cached) == ReuseDecision::reuse);
     CHECK(decide_manifest(true, cached, std::nullopt) == ReuseDecision::reuse_offline);
+    CHECK(decide_manifest(true, std::nullopt, std::nullopt) == ReuseDecision::refetch);
     CHECK(decide_manifest(false, cached, cached) == ReuseDecision::refetch);
 }
 

--- a/src/test/test_hf_cache.cpp
+++ b/src/test/test_hf_cache.cpp
@@ -1,0 +1,54 @@
+#include "network/hf_cache.hpp"
+
+#include <doctest/doctest.h>
+
+#include <filesystem>
+
+namespace
+{
+    using namespace zelph::network::detail::hf_cache;
+
+    RemoteMetadata metadata(const char* etag, const char* revision)
+    {
+        return {"hf://datasets/acrion/zelph/manifest.json", revision, etag, 123, 42};
+    }
+}
+
+TEST_CASE("HF manifest cache revalidates identities")
+{
+    const auto cached = metadata("\"old\"", "old-revision");
+    const auto current = metadata("\"new\"", "new-revision");
+
+    CHECK(decide_manifest(true, cached, current) == ReuseDecision::refetch);
+    CHECK(decide_manifest(true, cached, cached) == ReuseDecision::reuse);
+    CHECK(decide_manifest(true, cached, std::nullopt) == ReuseDecision::reuse_offline);
+    CHECK(decide_manifest(false, cached, cached) == ReuseDecision::refetch);
+}
+
+TEST_CASE("HF object cache identity includes revision and range")
+{
+    const RemoteMetadata cached{"hf://datasets/acrion/zelph/shard", "revision-a", "\"same\"", 123, 42};
+    ObjectCoordinates same{"hf://datasets/acrion/zelph/shard", "revision-a", "\"same\"", 10, 20};
+    ObjectCoordinates changed_revision{"hf://datasets/acrion/zelph/shard", "revision-b", "\"same\"", 10, 20};
+
+    CHECK(decide_object(true, cached, same) == ReuseDecision::reuse);
+    CHECK(decide_object(true, cached, changed_revision) == ReuseDecision::refetch);
+    CHECK(decide_object(false, cached, same) == ReuseDecision::refetch);
+}
+
+TEST_CASE("HF cache sidecars round-trip escaped metadata")
+{
+    const auto path = std::filesystem::temp_directory_path() / "zelph-hf-cache-sidecar-test.meta";
+    const RemoteMetadata original{"hf://datasets/a/b/file\nname", "revision", "etag=value", 99, 1234};
+
+    REQUIRE(write_sidecar(path, original));
+    const auto loaded = read_sidecar(path);
+    REQUIRE(loaded.has_value());
+    CHECK(loaded->source_uri == original.source_uri);
+    CHECK(loaded->revision == original.revision);
+    CHECK(loaded->etag == original.etag);
+    CHECK(loaded->content_length == original.content_length);
+    CHECK(loaded->retrieved_at == original.retrieved_at);
+    std::error_code ignored;
+    std::filesystem::remove(path, ignored);
+}

--- a/src/test/test_hf_cache.cpp
+++ b/src/test/test_hf_cache.cpp
@@ -1,4 +1,5 @@
 #include "network/hf_cache.hpp"
+#include "network/hf_transfer.hpp"
 
 #include <doctest/doctest.h>
 
@@ -16,7 +17,7 @@ namespace
 
 TEST_CASE("HF manifest cache revalidates identities")
 {
-    const auto cached = metadata("\"old\"", "old-revision");
+    const auto cached  = metadata("\"old\"", "old-revision");
     const auto current = metadata("\"new\"", "new-revision");
 
     CHECK(decide_manifest(true, cached, current) == ReuseDecision::refetch);
@@ -29,8 +30,8 @@ TEST_CASE("HF manifest cache revalidates identities")
 TEST_CASE("HF object cache identity includes revision and range")
 {
     const RemoteMetadata cached{"hf://datasets/acrion/zelph/shard", "revision-a", "\"same\"", 123, 42};
-    ObjectCoordinates same{"hf://datasets/acrion/zelph/shard", "revision-a", "\"same\"", 10, 20};
-    ObjectCoordinates changed_revision{"hf://datasets/acrion/zelph/shard", "revision-b", "\"same\"", 10, 20};
+    ObjectCoordinates    same{"hf://datasets/acrion/zelph/shard", "revision-a", "\"same\"", 10, 20};
+    ObjectCoordinates    changed_revision{"hf://datasets/acrion/zelph/shard", "revision-b", "\"same\"", 10, 20};
 
     CHECK(decide_object(true, cached, same) == ReuseDecision::reuse);
     CHECK(decide_object(true, cached, changed_revision) == ReuseDecision::refetch);
@@ -39,7 +40,7 @@ TEST_CASE("HF object cache identity includes revision and range")
 
 TEST_CASE("HF cache sidecars round-trip escaped metadata")
 {
-    const auto path = std::filesystem::temp_directory_path() / "zelph-hf-cache-sidecar-test.meta";
+    const auto           path = std::filesystem::temp_directory_path() / "zelph-hf-cache-sidecar-test.meta";
     const RemoteMetadata original{"hf://datasets/a/b/file\nname", "revision", "etag=value", 99, 1234};
 
     REQUIRE(write_sidecar(path, original));
@@ -52,4 +53,104 @@ TEST_CASE("HF cache sidecars round-trip escaped metadata")
     CHECK(loaded->retrieved_at == original.retrieved_at);
     std::error_code ignored;
     std::filesystem::remove(path, ignored);
+}
+
+TEST_CASE("HF transfer budgets use conservative host throughput")
+{
+    using namespace zelph::network::detail::hf_transfer;
+
+    const Limits limits{};
+    CHECK(conservative_rate(std::nullopt, limits) == 262144);
+    CHECK(conservative_rate(HostStats{"huggingface.co", 1048576, 3}, limits) == 262144);
+    CHECK(conservative_rate(HostStats{"huggingface.co", 1024, 3}, limits) == 65536);
+    CHECK(payload_timeout_seconds(16ULL * 1024 * 1024, 262144, limits) == 301);
+}
+
+TEST_CASE("HF transfer command includes phase-aware curl limits")
+{
+    using namespace zelph::network::detail::hf_transfer;
+
+    const Limits  limits{};
+    const Request probe{Operation::probe, "hf://datasets/a/b/manifest.json", "https://example.test/manifest.json", {}, "/tmp/headers", "/tmp/metrics", {}, {}, 0, 0};
+    const auto    probe_command = build_curl_command(probe, limits, 262144);
+    CHECK(probe_command.find("--connect-timeout 15") != std::string::npos);
+    CHECK(probe_command.find("--max-time 45") != std::string::npos);
+    CHECK(probe_command.find("--retry-max-time 45") != std::string::npos);
+    CHECK(probe_command.find(" -I ") != std::string::npos);
+
+    const Request fetch{Operation::fetch, "hf://datasets/a/b/shard", "https://example.test/shard", "/tmp/body", {}, "/tmp/metrics", "revision", "etag", 10, 20};
+    const auto    fetch_command = build_curl_command(fetch, limits, 262144);
+    CHECK(fetch_command.find("--speed-limit 1024") != std::string::npos);
+    CHECK(fetch_command.find("--speed-time 90") != std::string::npos);
+    CHECK(fetch_command.find("--range 10-29") != std::string::npos);
+}
+
+TEST_CASE("HF transfer metrics classify completed slow and stalled calls")
+{
+    using namespace zelph::network::detail::hf_transfer;
+
+    const Request fetch{Operation::fetch, "hf://datasets/a/b/shard", "https://example.test/shard", "/tmp/body", {}, "/tmp/metrics", {}, {}, 0, 1024 * 1024};
+    Metrics       completed{};
+    completed.curl_exit                = 0;
+    completed.average_bytes_per_second = 100000;
+    CHECK(classify(fetch, completed, 262144) == Outcome::slow_completed);
+    completed.average_bytes_per_second = 262144;
+    CHECK(classify(fetch, completed, 262144) == Outcome::completed);
+
+    Metrics stalled{};
+    stalled.curl_exit                = 28;
+    stalled.connect_milliseconds     = 1;
+    stalled.received_bytes           = 10;
+    stalled.average_bytes_per_second = 1;
+    CHECK(classify(fetch, stalled, 262144) == Outcome::stalled);
+
+    Metrics response_timeout{};
+    response_timeout.curl_exit            = 28;
+    response_timeout.connect_milliseconds = 1;
+    CHECK(classify(fetch, response_timeout, 262144) == Outcome::response_timeout);
+}
+
+TEST_CASE("HF transfer metrics parse curl JSON")
+{
+    using namespace zelph::network::detail::hf_transfer;
+
+    const auto path = std::filesystem::temp_directory_path() / "zelph-hf-transfer-metrics.json";
+    {
+        std::ofstream output(path);
+        output << R"({"time_namelookup":0.01,"time_connect":0.02,"time_appconnect":0.03,"time_starttransfer":0.04,"time_total":0.50,"size_download":1234,"speed_download":2468,"http_code":200,"exitcode":0})";
+    }
+    const auto metrics = read_metrics(path);
+    REQUIRE(metrics.has_value());
+    CHECK(metrics->dns_milliseconds == 10);
+    CHECK(metrics->connect_milliseconds == 20);
+    CHECK(metrics->tls_milliseconds == 30);
+    CHECK(metrics->first_byte_milliseconds == 40);
+    CHECK(metrics->total_milliseconds == 500);
+    CHECK(metrics->received_bytes == 1234);
+    CHECK(metrics->average_bytes_per_second == 2468);
+    CHECK(metrics->http_status == 200);
+    CHECK(metrics->curl_exit == 0);
+    std::error_code ignored;
+    std::filesystem::remove(path, ignored);
+}
+
+TEST_CASE("HF transfer throughput history ignores latency-dominated objects")
+{
+    using namespace zelph::network::detail::hf_transfer;
+
+    const auto      root = std::filesystem::temp_directory_path() / "zelph-hf-transfer-host-stats";
+    std::error_code ignored;
+    std::filesystem::remove_all(root, ignored);
+    std::filesystem::create_directories(root);
+    Metrics metrics{};
+    metrics.average_bytes_per_second = 1024 * 1024;
+
+    update_host_stats(root, "huggingface.co", 31, metrics);
+    CHECK_FALSE(read_host_stats(host_stats_path(root, "huggingface.co")).has_value());
+
+    update_host_stats(root, "huggingface.co", 64 * 1024, metrics);
+    const auto stored = read_host_stats(host_stats_path(root, "huggingface.co"));
+    REQUIRE(stored.has_value());
+    CHECK(stored->throughput_bytes_per_second == 1024 * 1024);
+    std::filesystem::remove_all(root, ignored);
 }


### PR DESCRIPTION
## Summary

- add a dedicated versioned HF cache policy layer
- revalidate manifests using resolved ETag/repository revision metadata
- key shard and binary-range cache entries by remote identity and byte range
- allow `ZELPH_HF_CACHE_DIR` to select the cache root
- reuse cached manifests with a warning when metadata checks are unavailable
- add offline policy tests and a live tamper/refetch regression helper
- document the cache contract and regression workflow

## Root cause

Manifest cache entries were effectively keyed by URI and zero length, so a
previous manifest could be reused indefinitely. Payload ranges were likewise
not bound to the revision of the remote artifact. After a dump regeneration,
old ranges could therefore be mixed with a new manifest without an error.

## Validation

- `ctest --test-dir build-hf-cache --output-on-failure -R zelph_tests`
- 156/156 tests passed
- focused HF cache tests: 3/3 passed
- live pruned-manifest load succeeded for all four section chunk 0s
- tampered cached manifest plus stale ETag was refetched successfully
- selected live payload was 778,058,079 bytes (~742 MiB)

The live helper is network- and Hub-state-dependent; it does not mutate the
Hub.

## Performance findings and follow-ups

The published pruned artifact was benchmarked with the new build:

- `meta-only`: 111,981-byte manifest plus 31-byte header; no shard payloads
  downloaded. Cold: 2.34 s; hot: 0.93 s.
- `left=0` only: 232,194,888 bytes (~222 MiB), 49.1 s in the test run.
- `left=0`, `right=0`, `nameOfNode=0`, `nodeOfName=0`: 778,058,079 bytes
  (~742 MiB) total.

This confirms that manifest-based partial loading does not download the full
binary or all shards. The remaining cost is the shard granularity: a selected
chunk currently represents a large block of entries. Suggested follow-up work:

- add a repeatable cold/hot performance benchmark for metadata-only, one
  section, and multi-section loads;
- consider smaller shards or a routed/indexed artifact for fine-grained node
  access, since `nodeRouteIndex: false` is valid but cannot reduce a selected
  chunk below its published granularity;
- expose cache-hit, revalidation, transfer-byte, and elapsed-time diagnostics;
- add bounded curl connect/transfer timeouts and clearer retry diagnostics;
- consider pinning an entire load to the repository revision resolved when the
  manifest is fetched, for atomic manifest/shard consistency.

## Larger-query execution direction

The intended use case is not merely loading a smaller graph. Partial loading
should support joins that exceed native in-memory WD/SPARQL limits through an
asynchronous, progressive executor:

```text
SPARQL query
→ logical join tree
→ cost/selectivity estimates
→ shard request plan
→ bounded async HF fetches
→ incremental joins
→ reprioritised requests
→ progressive results
```

The planned executor should:

- build a join tree from predicate cardinality, shard statistics, and route
  indexes;
- schedule branches by expected join-space reduction per fetch cost;
- use bounded concurrency rather than unbounded async tasks;
- feed completed shards into streaming/semi-joins;
- spill large intermediate relations to disk;
- update priorities as observed selectivity changes;
- cancel or deprioritise work made unnecessary by earlier results;
- reuse cached manifests, shards, and intermediate relations.

The planner should be adaptive rather than assuming a permanently optimal
tree. A useful priority signal is:

```text
expected reduction in unresolved join space / fetch cost
```

Results need explicit completeness state:

```text
progressive result:
  discovered matches
  pending shard work
  unresolved coverage

complete result:
  required coverage exhausted
  no pending shard work
  completeness receipt attached
```

Partial loading bounds memory, but it does not make an all-shard join cheap by
itself. Query-oriented routing, predicate statistics, semi-join reduction,
bounded hash joins, and spill-to-disk are the follow-on layers needed to turn
remote shards into a practical large-query engine. The result must never imply
completeness while relevant shard coverage remains unresolved.
